### PR TITLE
Minimal 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 1.0.5
+## 2.0.0
+
+* Document minimal manager
+* Remove minimal state (breaking change), easing notifiers with primitives
+* Improve MMMNotifier notify()
+* Improve internal value notifier for selection
+* Make selection read-only (breaking change)
+
+## 1.0.5 (retracted)
 
 * Document minimal manager
 * Remove minimal state (breaking change), easing notifiers with primitives

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -398,7 +398,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.5"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: minimal_mvn
 description: A minimal state management solution for Flutter apps using the Model-View-Notifier (MVN) pattern
-version: 1.0.5
+version: 2.0.0
 repository: https://github.com/alesalv/minimal
 homepage: https://github.com/alesalv/minimal
 


### PR DESCRIPTION
This PR replaces the [retracted 1.0.5](https://github.com/alesalv/minimal/pull/8) as I introduced breaking changes.

* Document minimal manager
* Remove minimal state (breaking change), easing notifiers with primitives
* Improve MMMNotifier notify()
* Improve internal value notifier for selection
* Make selection read-only (breaking change)
